### PR TITLE
25-3장 클래스 - 고세종

### DIFF
--- a/docs/25_클래스/고세종.md
+++ b/docs/25_클래스/고세종.md
@@ -211,3 +211,218 @@ private 필드는 반드시 클래스 몸체에 정의해야 하며 직접 const
 현재의 자바스크립트는 `static`을 이용한 정적 메서드를 정의할 수 있는 기능 뿐만 아니라 정적 필드를 정의할 수 있는 기능을 제공한다.
 
 클래스 필드 앞에 `static`키워드를 붙여 사용한다.
+
+---
+
+## 클래스 상속
+
+프로토타입 기반의 상속과 마찬가지로 클래스도 상속의 기능을 제공한다.<br>
+하지만 이 둘은 차이점이 있다.
+
+프로토타입 기반의 상속은 프로토타입 체인을 통해 다른 객체의 자산을 상속받는 개념이지만, 상속에 의한 클래스 확장은 기존 클래스를 상속받아 새로운 클래스를 확장하여 정의하는 것이다.
+
+클래스와 생성자 함수는 인스턴스를생성할 수 있는 함수라는 점에서 매우 유사하지만,<br>
+클래스는 상속을 통해 기존 클래스를 확장할 수 있는 문법이 제공된다.
+
+예를 들어보자.
+
+`동물`,`새`,`사자`라는 3가지 클래스가 있다고 생각해보자.<br>
+기본적으로 새와 사자는 동물이라는 성질을 가지고 있으니 동물에 해당하는 공통 특징을 상속 받을 수 있다.<br>
+따라서, 동물의 공통 특징을 상속받고 새와 사자 클래스가 각 고유 특징을 가지고 있게 된다면 상속에 의한 클래스 확장이 이루어 지며, 이는 코드 재사용 관점에서 매우 유용하다.
+
+실제로 `동물` 클래스를 상속 받은 `새` 클래스를 구현해보자.
+
+```javascript
+class Animal {
+  constructor(age, weight) {
+    this.age = age;
+    this.weight = weight;
+  }
+
+  eat() {
+    return 'eat';
+  }
+
+  move() {
+    return 'move';
+  }
+}
+
+class Bird extends Animal {
+  fly() {
+    return 'fly';
+  }
+}
+
+const bird = new Bird(1, 5);
+
+console.log(bird); // Bird {age: 1, weight: 5}
+console.log(bird instanceof Bird); // true
+console.log(bird instanceof Animal); // true
+
+console.log(bird.eat()); // eat
+console.log(bird.move()); // move
+console.log(bird.fly()); // fly
+```
+
+상속은 `extends` 키워드를 사용하며, 이렇게 상속에 의해 확장된 클래스 `Bird`는 `Amimal` 클래스와 연결되며, 생성된 `bird` 인스턴스는 `Bird.prototype`과 또 이는 `Animal.prototype`과 체인이 연결된다.<br>
+따라서 `bird.eat(), bird.move()`가 가능한것이다.
+
+상속을 통해 확장된 클래스를 서브 클래스라 하고, 서브클래스에게 상속된 클래스를 수퍼클래스라 한다.<br>
+자식 클래스, 부모 클래스라 하기도 한다.
+
+위 예제에서 확인 했듯이 상속시 인스턴스의 프로토타입 체인뿐 아니라 클래스 간의 프로토타입 체인도 생성되며, 이를 통해 프로토타입 메서드, 정적 메서드 전부 상속이 가능하다.
+
+### 동적 상속
+
+`extends`키워드를 사용한 상속은 클래스에만 한정되어 있지 않다.
+
+클래스 뿐만 아니라 `[[Construct]]` 내부 메서드를 갖는 함수 객체로 평가될 수 있는 모든 표현식을 사용할 수 있는데,<br>
+이는 동적으로 상속 받을 대상을 결정할 수 있게 해준다.
+
+> `[[Construct]]` 내부 메서드를 갖는 표현식은 함수 선언식, 함수 표현식, 화살표 함수, Function 생성자가 있다.<br>
+> 추가로, Function 생성자 뿐만 아니라 다른 표준 빌트인 생성자 함수도 상속이 가능하다.
+
+### 서브클래스의 constructor
+
+앞절에서 봤듯이 `constructor`는 생략가능하며, 생략시 비어있는 constructor가 암묵적으로 정의된다고 했다.
+
+만약, 상속받은 자식 클래스에서 constructor를 생략하면 어떻게 될까.
+
+```javascript
+constructor(...args) {super(...args)}
+```
+
+위와 같이암묵적으로 비어있는 constructor가 생성되고 `new`연산자와 함께 클래스를 호출할 때 전달한 인수의 리스트는 `...args`를 통해,
+또, `super()`를 통해 부모 클래스의 생성자 함수를 호출하여 인스턴스를 생성하게 된다.
+
+프로퍼티를 소유하는 인스턴스를 생성하려면 constructor 내부에서 인스턴스에 프로퍼티를 추가해야 한다.
+
+### super
+
+`super`는 함수처럼 호출할 수도 있고, `this`와 같이 식별자처럼 참조할 수 있는 특수한 키워드이다.
+
+호출할 경우 수퍼 클래스(부모 클래스)의 `constructor(super-constructor)`를 호출하고, 참조시 수퍼 클래스의 메서드를 호출할 수 있다.
+
+```javascript
+class Base {
+  constructor(a, b) {
+    this.a = a;
+    this.b = b;
+  }
+}
+
+class Derived extends Base {}
+
+const derived = new Derived(1, 2);
+console.log(derived); // Derived {a:1, b:2}
+```
+
+위 예제는 super를 호출한 경우이다.
+
+`Derived`클래스에 생성자 함수가 없음에도 불구하고 `console.log(derived)`에서 `{a:1, b:2}`가 반환되는것을 확인할 수 있는데,
+이는 `Derived`클래스 내부 암묵적으로 `constructor(...args) {super(...args)}`가 정의된 결과이다.<br>
+
+따라서 `Derived`클래스로 전달된 인수들은 `super(...args)`를 통해 부모 클래스로 전달되어 인스턴스가 생성된다.
+
+```javascript
+class Base {
+  constructor(a, b) {
+    this.a = a;
+    this.b = b;
+  }
+}
+
+class Derived extends Base {
+  constructor(a, b, c) {
+    super(a, b);
+    this.c = c;
+  }
+}
+
+const derived = new Derived(1, 2, 3);
+console.log(derived); // {a: 1, b: 2, c: 3}
+```
+
+위 예제는 자식 클래스 내부에서 생성자 함수를 생략하지 않고 `super`를 직접 호출하는 예제이다.<br>
+
+앞전에 먼저 참고한 예제를 통해 `Derived` 클래스 생성을 통해 전달된 인수 1,2,3중 1,2는 super를 통해 부모 클래스로 전달되는 것을 알 수 있다.
+
+하지만 super를 직접 호출할때 몇가지 주의사항이 있다.
+
+1. 서브클래스에서 constructor를 생략하지 않는 경우 서브클래스의 constructor에서는 반드시 super를 호출해야 한다.
+2. 서브클래스의 constructor에서 super를 호출하기 전에는 this를 참조할 수 없다.
+3. super는 반드시 서브클래스의 constructor에서만 호출한다. 서브 클래스가 아닌 클래스의 constructor나 함수에서 super를 호출하면 에러가 발생한다.
+
+다음 예제를 통해 super를 참조하는 방법을 알아보자.
+
+```javascript
+class Base {
+  constructor(name) {
+    this.name = name;
+  }
+
+  sayHi() {
+    return `Hi! ${this.name}`;
+  }
+}
+
+class Derived extends Base {
+  sayHi() {
+    return `${super.sayHi()}. how are you doing ?`;
+  }
+}
+
+const derived = new Derived('Lee');
+console.log(derived.sayHi()); // Hi! Lee. how are you doing ?
+```
+
+super 참조를 통해 수퍼클래스의 메서드를 참조하려면 super가 수퍼클래스의 메서드가 바인딩된 객체, 즉, 수퍼클래스의 prototype 프로퍼티에 바인딩된 프로토타입을 참조할 수 있어야 한다.
+
+> 간단히 말하자면, `super`를 사용하여 메서드를 호출할때 해당 메서드는 수퍼 클래스의 프로토타입에 정의 되어 있어야 된다는 말이다.
+
+### 상속 클래스의 인스턴스 생성 과정
+
+위에서 super를 통해 인자가 전달되고 부모 클래스의 프로퍼티를 가지고 인스턴스가 생성되는게 이해가 잘 되지 않았다.<br>
+이를 이해하기 위해 생성 과정을 알아보자.
+
+1. **서브클래스의 super 호출**
+
+자바스크립트 엔진은 클래스를 평가할 때 수퍼클래스와 서브클래스를 구분하기 위해 `[[ConstructorKind]]` 내부 슬롯을 이용한다.<br>
+다른 클래스를 상속받지 않는 클래스는 이 내부 슬롯의 값이 `base`로 설정 되지만, 상속 받는 서브 클래스는 내부 슬롯 값이 `derived`로 설정된다.
+
+서브클래스는 자신이 직접 인스턴스를 생성하지 않고 수퍼클래스에게 인스턴스 생성을 위임한다.<br>
+이러한 이유 때문에 서브클래스의 constructor에서 반드시 super를 호출해야 하는 이유이다.
+
+> 이것이 서브클래스에서 반드시 super를 호출해야 하는 이유이다.
+
+2. **수퍼클래스의 인스턴스 생성과 this 바인딩**
+
+인스턴스가 생성될때 수퍼클래스의 생성자 함수 constructor의 내부 코드가 실행되기 이전에 암묵적으로 빈 객체를 생성한다.<br>
+그후, 이 빈 객체에 this가 바인딩되고, 이 this는 생성된 인스턴스를 가르키게 된다.
+
+하지만, new 연산자와 함께 호출된 클래스는 서브클래스 이기 때문에 인스턴스는 `new.target`이 가르키는 서브클래스가 생성한 것으로 처리된다.<br>
+따라서, 생성된 인스턴스의 프로토타입은 서브클래스의 prototype 프로퍼티가 가르키는 객체가 된다.
+
+> new.target은 생성자 함수에서 사용되며, new 키워드를 통해 함수가 호출 됐는지 확인하며, 해당 생성자 함수를 참조한다.
+
+3. **수퍼클래스의 인스턴스 초기화**
+
+this에 바인딩되어 있는 인스턴스에 프로퍼티를 추가하고 인수로 전달받은 초기값으로 인스턴스의 프로퍼티를 초기화한다.
+
+4. **서브클래스 constructor로의 복귀와 this 바인딩**
+
+super 호출이 종료되고 제어 흐름이 서브클래스의 constructor로 돌아온다.<br>
+이때 super가 반환한 인스턴스가 this에 바인딩된다. 서브클래스는 별도의 인스턴스를 생성하지 않고 super가 반환한 인스턴스를 this에 바인딩하여 그대로 사용한다.
+
+따라서, super가 호출되지 않으면 인스턴스가 생성되지 않으며, this 바인딩도 할 수 없다.<br>
+서브클래스의 constructor에서 super를 호출하기 전에는 this를 참조할 수 없는 이유가 바로 이 때문이다.
+
+5. **서브 클래스의 인스턴스 초기화**
+
+super 호출 이후, 서브 클래스의 constructor에 기술되어 있는 인스턴스 초기화가 실행된다.<br>
+수퍼 클래스로 부터 전달받은 인스턴스에 프로퍼티를 추가하고 값을 초기화 한다.
+
+6. **인스턴스 반환**
+
+클래스의 모든 처리가 끝나면 완성된 인스턴스가 바인딩된 this가 암묵적으로 반환된다.


### PR DESCRIPTION
## Q1. 정적 메서드와 프로토타입 메서드의 차이를 작성해 주세요.
### A1.

1. 정적 메서드와 프로토타입 메서드는 자신이 속해 있는 프로토타입 체인이 다르다.
2. 정적 메서드는 클래스로 호출하고, 프로토타입 메서드는 인스턴스로 호출한다.
3. 정적 메서드는 인스턴스 프로퍼티를 참조할 수 없지만, 프로토타입 메서드는 인스턴스 프로퍼티를 참조할 수 있다.

정적 메서드는 클래스 내부에 속해 있는 메서드이고, 프로토타입 메서드는 클래스가 생성됐을때 같이 생성된 프로토타입에 속해있는 메서드이다.
따라서, 속해있는 프로토타입 체인이 다르며 호출방식도 다른것이다.

또한, 클래스를 통해 생성된 인스턴스는 클래스와 직접적으로 연결되는 것이 아닌 클래스의 프로토타입과 연결되기 때문에 정적 메서드는 인스턴스 프로퍼티를 참조할 수 없지만, 프로토타입 메서드는 참조할 수 있게 된다.

---

## Q2. 클래스 호이스팅은 어떻게 동작하는지 설명해 주세요.
### A2.

클래스 선언문으로 정의한 클래스는 함수 선언문과 같이 소스코드 평가 과정, 즉 런타임 이전에 먼저 평가되어 함수 객체를 생성한다.
이때 평가되어 생성되는 함수 객체는 생성자 함수(constructor)이며, 생성자 함수가 생성되는 시점에 프로토타입도 같이 생성된다.

클래스 또한 `let, const`키워드로 선언한 변수처럼 호이스팅 된다.
let, const 키워드로 선언한 변수는 호이스팅이 이루어져 선언은 평가 과정에 이루어 지지만 초기화는 런타임 시점에 일어난다.
따라서, 클래스도 선언문 이전에 참조할경우 에러가 반환된다.

---

## Q3. OX 퀴즈 (정답과 그 이유를 간단히 적어주세요)
### A3.

1. 클래스 이름은 무조건 파스칼 케이스로 지어야 한다.
X. 파스칼 케이스는 일반적 권고사항이다.

2. 클래스는 선언 이전에 참조할 수 없다.
O. 클래스는 `let, const`로 선언된 변수와 같이 호이스팅이 이뤄지기 때문에 런타임 시점에 할당이 이루어 진다.

3. 클래스에서 정의한 메서드는 모두 non-constructor이다.
O. 내부 메서드 [[Construct]]를 갖지 않으며 new 연산자와 함께 호출할 수 없기 때문이다.

4. 클래스에서 getter, setter 메서드를 정의하면 인스턴스의 프로퍼티 메서드가 된다.
X. 클래스의 메서드는 기본적으로 프로토타입 메서드가 되기에 접근자 프로퍼티 또한 인스턴스 프로퍼티가 아닌 프로토타입의 프로퍼티가 된다.

---

## Q4. 다음 코드를 보고 에러가 나는 부분 번호와 그 이유를 적어주세요.
### A4.

(3). 상속을 통해 생성되는 인스턴스는 수퍼 클래스를 통해 먼저 생성되며 생성된 인스턴스가 서브 클래스로 전달되어 프로퍼티 초기화가 이루어 진다. 따라서 super 호출 이전에 this 바인딩은 일어날 수 없다.

---

Quiz: #1045  

퀴즈 작성하시느라 고생하셨습니다.

감사합니다 :)