### PR TITLE
25-3장 클래스 - 나세현

### DIFF
--- a/docs/25_클래스/나세현.md
+++ b/docs/25_클래스/나세현.md
@@ -464,3 +464,180 @@ class MyMath {
 console.log(MyMath.PI); // 3.14.........
 console.log(MyMath.increment()); // 11
 ```
+
+### ✨ 25.8: 상속에 의한 클래스 확장
+
+#### 클래스 상속과 생성자 함수 상속
+
+프로토타입 기반 상속은 프로토타입 체인을 통해 다른 객체의 자산을 상속받는 개념이지만, **상속에 의한 클래스 확장은 기존 클래스를 상속받아 새로운 클래스를 확장하여 정의**하는 것이다.  
+클래스와 생성자 함수는 둘 다 인스턴스를 생성할 수 있는 함수라는 점에서는 유사하지만, 클래스는 상속을 통해 기존 클래스를 확장할 수 있는 문법이 있는 반면 생성자 함수는 그렇지 않다.
+
+```javascript
+class Animal {
+  constructor(age, weight) {
+    this.age = age;
+    this.weight = weight;
+  }
+
+  eat() {
+    return 'eat';
+  }
+
+  move() {
+    return 'move';
+  }
+}
+
+// 상속을 통해 Animal 클래스를 확장한 Bird 클래스
+class Bird extends Animal {
+  fly() {
+    return 'fly';
+  }
+}
+
+const bird = new Bird(1, 5);
+
+console.log(bird); // { age: 1, weight: 5 }
+console.log(bird instanceof Bird); // true
+console.log(bird instanceof Animal); // true
+
+console.log(bird.eat()); // eat
+console.log(bird.move()); // move
+console.log(bird.fly()); // fly
+```
+
+#### `extends` 키워드
+
+상속을 통해 클래스를 확장하려면 `extends` 키워드를 사용해 상속받을 클래스를 정의한다.  
+상속을 통해 확장된 클래스르 서브클래스, 서브클래스에게 상속된 클래스를 수퍼클래스라고 부른다.  
+수퍼클래스와 서브클래스는 인스턴스의 프로토타입 체인뿐 아니라 클래스 간의 프로토타입 체인도 생성한다.
+
+#### 동적 상속
+
+`extends` 키워드는 클래스뿐만 아니라 생성자 함수를 상속받아 클래스를 확장할 수도 있다.  
+단, `extends` 키워드 앞에는 반드시 클래스가 와야 한다.
+
+```javascript
+function Base(a) {
+  this.a = a;
+}
+
+class Derived extends Base {}
+
+const derived = new Derived(1);
+console.log(derived); // Derived { a: 1 }
+```
+
+`extends` 키워드 다음에는 클래스뿐만 아니라 `[[Construct]]` 내부 메서드를 갖는 함수 객체로 평가될 수 있는 모든 표현식을 사용할 수 있다.
+
+```javascript
+function Base1() {}
+
+class Base2 {}
+
+let condition = true;
+
+class Derived extends (condition ? Base1 : Base2) {}
+
+const derived = new Derived();
+console.log(derived); // Derived {}
+
+console.log(derived instanceof Base1); // true
+console.log(derived instanceof Base2); // false
+```
+
+#### 서브클래스의 `constructor`
+
+앞에서 살펴보았듯이 클래스에서 `constructor`를 생략하면 클래스에 비어 있는 `constructor`가 암묵적으로 정의된다.  
+서브클래스에서 `constructor`를 생략하면 클래스에 다음과 같은 `constructor`가 암묵적으로 정의된다.  
+`args`는 `new` 연산자와 함께 클래스를 호출할 때 전달한 인수의 리스트다.
+
+```javascript
+constructor(...args) { super(...args) }
+```
+
+`super()`는 수퍼클래스의 `constructor`를 호출하여 인스턴스를 생성한다.
+
+```javascript
+class Base {}
+
+class Derived extends Base {}
+
+const derived = new Derived();
+consoe.log(derived); // Derived {}
+```
+
+#### `super` 키워드
+
+`super` 키워드는 함수처럼 호출할 수도 있고 `this`와 같이 식별자처럼 참조할 수 있는 특수한 키워드다.
+
+- `super`를 호출하면 수퍼클래스의 `constructor`를 호출한다.
+- `super`를 참조하면 수퍼클래스의 메서드를 호출할 수 있다.
+
+수퍼클래스의 `constructor` 내부에서 추가한 프로퍼티를 그대로 갖는 인스턴스를 생성한다면 서브클래스의 `constructor`를 생략할 수 있지만, 다음 예제처럼 수퍼클래스에서 추가한 프로퍼티와 서브클래스에서 추가한 프로퍼티를 갖는 인스턴스를 생성한다면 생략할 수 없다.
+
+```javascript
+class Base {
+  constructor(a, b) {
+    this.a = a;
+    this.b = b;
+  }
+}
+
+class Derived extends Base {
+  constructor(a, b, c) {
+    super(a, b);
+    this.c = c;
+  }
+}
+
+const derived = new Derived(1, 2, 3);
+console.log(derived); // Derived { a: 1, b: 2, c: 3 }
+```
+
+`super`를 호출할 때 주의할 사항은 다음과 같다.
+
+1. 서브클래스에서 `constructor`를 생략하지 않는 경우 서브클래스의 `constructor`에서는 반드시 `super`를 호출해야 한다.
+2. 서브클래스의 `constructor`에서 `super`를 호출하기 전에는 `this`를 참조할 수 없다.
+3. `super`는 반드시 서브클래스의 `constructor`에서만 호출한다. 서브클래스가 아닌 클래스의 `constructor` 함수에서 호출 시 에러가 발생한다.
+
+메서드 내에서 `super`를 참조하면 수퍼클래스의 메서드를 호출할 수 있다.
+
+```javascript
+class Base {
+  constructor(name) {
+    this.name = name;
+  }
+
+  sayHi() {
+    return `Hi, ${this.name}!`;
+  }
+}
+
+class Derived extends Base {
+  sayHi() {
+    return `${super.sayHi()} How are you doing?`;
+  }
+}
+
+const derived = new Derived('Lee');
+console.log(derived.sayHi()); // Hi, Lee! How are you doing?
+```
+
+서브클래스의 정적 메서드 내에서 `super.sayHi`는 수퍼클래스의 정적 메서드 `sayHi`를 가리킨다.
+
+```javascript
+class Base {
+  static sayHi() {
+    return 'Hi!';
+  }
+}
+
+class Derived extends Base {
+  static sayHi() {
+    return `${super.sayHi()} How are you doing?`;
+  }
+}
+
+console.log(Derived.sayHi()); // Hi! How are you doing?
+```


### PR DESCRIPTION
## Q1. 정적 메서드와 프로토타입 메서드의 차이를 작성해주세요.
1. 정적 메서드와 프로토타입 메서드는 속해 있는 프로토타입 체인이 다르다.
2. 정적 메서드는 클래스로, 프로토타입 메서드는 인스턴스로 호출한다.
3. 정적 메서드는 인스턴스 프로퍼티를 참조할 수 없지만 프로토타입 메서드는 참조할 수 있다.

## Q2. 클래스 호이스팅은 어떻게 동작하는지 설명해주세요.
클래스 선언문은 `let`, `const` 키워드로 선언한 변수처럼 호이스팅되기 때문에 선언문 이전에 tdz에 빠져 호이스팅이 되지 않는 것처럼 동작(선언 이전에 참조가 불가능)한다.

## Q3. OX 퀴즈 (정답과 그 이유를 간단히 적어주세요)
1. 클래스 이름은 무조건 파스칼 케이스로 지어야 한다. - ❎, 파스칼 케이스를 사용하는 것이 일반적일 뿐 사용하지 않아도 에러가 발생하지는 않는다.
2. 클래스는 선언 이전에 참조할 수 없다. - 🅾️, `let`, `const`로 선언한 변수처럼 호이스팅되기 때문에 tdz에 빠지기 때문이다.
3. 클래스에서 정의한 메서드는 모두 non-constructor다. - 🅾️, 내부 메서드 `[[Construct]]`를 갖지 않는 non-constructor다.
4. 클래스에서 getter, setter 메서드를 정의하면 인스턴스의 프로퍼티 메서드가 된다. - ❎, 클래스의 메서드는 기본적으로 프로토타입 메서드가 되므로 클래스의 접근자 프로퍼티 또한 인스턴스 프로퍼티가 아닌 프로토타입의 프로퍼티가 된다.

## Q4. 다음 코드를 보고 에러가 나는 부분 번호와 그 이유를 적어주세요.
```javascript
class Base {
  name = 'hyori'      // (1)
  constructor(a, b) {
    this.a = a
    this.b = b
    age = 24      // (2)
  }
}

class Derived extends Base {
  constructor(a, b, c, d) {
    this.c = c        // (3)
    super(a, b)
    this.d = d       // (4)
  }
  sayName() {
    console.log(this.name)
  }
}

const derived = new Derived(1, 2, 3)
derived.sayName()    // (5)
```
3️⃣, 서브클래스의 `constructor`에서 `super`를 호출하기 전에는 `this`를 참조할 수 없다.

Issue #1045 