### PR TITLE
25-3장 클래스 - 최주용

### DIFF
--- a/docs/25_클래스/최주용.md
+++ b/docs/25_클래스/최주용.md
@@ -410,3 +410,151 @@ class MyMath {
 console.log(MyMath.PI); // 3.142857 ..
 console.log(MyMath.increment()); // 11
 ```
+
+## 👉 25.8 상속에 의한 클래스 확장
+
+### 25.8.1 클래스 상속과 생성자 함수 상속
+
+프로토타입 기반 상속은 프로토타입 체인을 통해 다른 객체의 자산을 상속받는 개념이지만 **상속에 의한 클래스 확장은 기존 클래스를 상속받아 새로운 클래스를 확장<sup>extends</sup> 하여 정의**하는 것이다.
+
+클래스는 상속을 통해 다른 클래스를 확장할 수 있는 문법인 `extends` 키워드가 기본적으로 제공된다. extends 키워드를 사용한 클래스 확장은 간편하고 직관적이다. 하지만 생성자 함수는 클래스와 같이 상속을 통해 확장할 수 있는 문법이 제공되지 않는다.
+
+### 25.8.2 extends 키워드
+
+상속을 통해 클래스를 확장하려면 `extends` 키워드를 사용하여 상속받을 클래스를 정의한다.
+
+```javascript
+// 수퍼(베이스/부모) 클래스
+class Base {}
+
+// 서브(파생/자식) 클래스
+class Derived extends Base {}
+```
+
+상속을 통해 확장된 클래스를 서브클래스라 부르고, 서브클래스에게 상속된 클래스를 수퍼클래스라 부른다.
+
+수퍼클래스와 서브클래스는 인스턴스의 프로토타입 체인뿐 아니라 클래스 간의 프로토타입 체인도 생성한다. 이를 통해 프로토타입 메서드, 정적 메서드 모두 상속이 가능하다.
+
+### 25.8.3 동적 상속
+
+`extends` 키워드는 클래스뿐만 아니라 생성자 함수를 상속받아 클래스를 확장할 수도 있다. 단, extends 키워드 앞에는 반드시 클래스가 와야 한다.
+
+```javascript
+// 생성자 함수
+function Base(a) {
+  this.a = a;
+}
+
+// 생성자 함수를 상속받는 서브클래스
+class Derived extends Base {}
+
+const derived = new Derived(1);
+console.log(derived); // Derived {a: 1}
+```
+
+### 25.8.4 서브클래스의 constructor
+
+25.5.1절 "constructor"에서 살펴보았듯이 클래스에서 클래스 `constructor`를 생략하면 클래스에 다음과 같이 비어있는 constructor가 암묵적으로 정의된다.
+
+```javascript
+constructor() {}
+```
+
+다음은 수퍼클래스와 서브클래스 모두 `constructor`를 생략했다.
+
+```javascript
+// 수퍼클래스
+class Base {}
+
+// 서브클래스
+class Derived extends Base {}
+```
+
+위 예제의 클래스에는 다음과 같이 암묵적으로 constructor가 정의된다.
+
+```javascript
+// 수퍼클래스
+class Base {
+  constructor() {}
+}
+
+// 서브클래스
+class Derived extends Base {
+  constructor(...args) {
+    super(...args);
+  }
+}
+
+const derived = new Derived();
+console.log(derived); // Derived {}
+```
+
+### 25.8.5 super 키워드
+
+`super` 키워드는 함수처럼 호출할 수도 있고 `this`와 같이 식별자처럼 참조할 수 있는 특수한 키워드다. 다음과 같이 동작한다.
+
+- super를 호출하면 수퍼클래스의 constructor를 호출한다.
+- super를 참조하면 수퍼클래스의 메서드를 호출할 수 있다.
+
+### 25.8.6 상속 클래스의 인스턴스 생성 과정
+
+상속 관계에 있는 두 클래스가 어떻게 협력하며 인스턴스를 생성하는지 살펴보자.
+
+```javascript
+// 수퍼클래스
+class Rectangle {
+  constructor(width, height) {
+    this.width = width;
+    this.height = height;
+  }
+
+  getArea() {
+    return this.width + this.height;
+  }
+
+  toString() {
+    return `width = ${this.width}, height = ${this.height}`;
+  }
+}
+
+// 서브클래스
+class ColorRectangle extends Rectangle {
+  constructor(width, height, color) {
+    super(width, height);
+    this.color = color;
+  }
+
+  // 메서드 오버라이딩
+  toString() {
+    return super.toString() + `, color = ${this.color}`;
+  }
+}
+```
+
+서브클래스 `ColorRectangle`이 new 연산자와 함께 호출되면 다음 과정을 통해 인스턴스를 생성한다.
+
+1. 서브클래스의 super 호출
+   다른클래스를 상속받지 않는 클래스는 `new` 연산자와 함께 호출되었을 때 암묵적으로 빈 객체, 즉 인스턴스를 생성하고 이를 `this`에 바인딩한다.
+   하지만 **서브클래스는 자신이 직접 인스턴스를 생성하지 않고 수퍼클래스에게 인스턴스 생성을 위임한다. 이것이 바로 서브클래스의 `constructor`에서 반드시 `super`를 호출해야 하는 이유다.**
+
+2. 수퍼클래스의 인스턴스 생성과 this 바인딩
+   이때 인스턴스는 수퍼클래스가 생성한 것이다. 하지만 new 연산자와 함께 호출된 클래스는 서브클래스라는 것이 중요하다. 따라서 **인스턴스는 new.target이 가리키는 서브클래스가 생성한 것으로 처리된다.**
+
+3. 수퍼클래스의 인스턴스 초기화
+   수퍼클래스의 constructor가 실행되어 this에 바인딩되어 있는 인스턴스를 초기화한다.
+
+4. 서브클래스 constructor로의 복귀와 this 바인딩
+   `super` 호출이 종료되고 제어 흐름이 서브클래스 `constructor`로 돌아온다. **이때 super가 반환한 인스턴스가 this에 바인딩된다. 서브클래스는 별도의 인스턴스를 생성하지 않고 super가 반환한 인스턴스를 this에 바인딩하여 그대로 사용한다.**
+   **이처럼 super가 호출되지 않으면 인스턴스가 생성되지 않으며, this 바인딩도 할 수 없다. 서브클래스의 constructor에서 super를 호출하기 전에는 this를 참조할 수 없는 이유가 바로 이 때문이다.**
+
+5. 서브클래스의 인스턴스 초기화
+   `super` 호출 후, 서브클래스의 constructor에 기술되어 있는 인스턴스 초기화가 실행된다.
+
+6. 인스턴스 반환
+   클래스의 모든 처리가 끝나면 완성된 인스턴스가 반환된다.
+
+### 25.8.7 표준 빌트인 생성자 함수 확장
+
+"동적 상속"에서 살펴보았듯이 `extends` 키워드 다음에는 클래스뿐만 아니라 [[Construct]] 내부 메서드를 갖는 함수 객체로 평가될 수 있는 모든 표현식을 사용 가능하다.
+
+따라서, 표준 빌트인 객체도 [[Construct]] 내부 메서드를 갖는 생성자 함수이므로 extends 키워드를 사용하여 확장할 수 있다.


### PR DESCRIPTION
#1045 

Q1) 
1. 정적 메서드는 클래스로 호출하고, 프로토타입 메서드는 인스턴스로 호출한다.
2. 속해있는 프로토타입 체인이 다르다.
3. 정적 메서드는 인스턴스 프로퍼티를 참조할 수 없지만 프로토타입 메서드는 가능하다.

Q2)
클래스 호이스팅은 발생하지 않는 것 같지만 let, const 처럼 호이스팅이 일어난다. 선언과 초기화 단계가 분리되어 일어나기 때문에 "일시적 사각 지대"에 빠지게 된다.

Q3)
X - 파스칼 케이스를 사용하는 것이 권고되는 것일 뿐이다.
O - 일시적 사각지대에 빠지게 때문에 에러가 발생한다.
O - 모두 non-constructor 이기 때문에 new 연산자와 함께 호출할 수 없다.
X - 클래스의 메서드는 기본적으로 프로토타입 메서드가 되기 때문에, 접근자 프로퍼티 또한 프로토타입의 프로터티가 된다.

Q4)
(3) - 서브클래스는 super 호출로 인스턴스를 생성하기 때문에 super 호출 이전에 this를 참조할 수 없다.
